### PR TITLE
v2.4.8

### DIFF
--- a/aomaker/__init__.py
+++ b/aomaker/__init__.py
@@ -1,6 +1,6 @@
 from emoji import emojize
 
-__version__ = "2.4.7"
+__version__ = "2.4.8"
 __description__ = "Quickly Arrange,Quickly Test!"
 __image__ = emojize(fr"""
               :----.                                                             ::::

--- a/aomaker/__init__.py
+++ b/aomaker/__init__.py
@@ -1,6 +1,6 @@
 from emoji import emojize
 
-__version__ = "2.4.5"
+__version__ = "2.4.6"
 __description__ = "Quickly Arrange,Quickly Test!"
 __image__ = emojize(fr"""
               :----.                                                             ::::

--- a/aomaker/__init__.py
+++ b/aomaker/__init__.py
@@ -1,6 +1,6 @@
 from emoji import emojize
 
-__version__ = "2.4.6"
+__version__ = "2.4.7"
 __description__ = "Quickly Arrange,Quickly Test!"
 __image__ = emojize(fr"""
               :----.                                                             ::::

--- a/aomaker/_aomaker.py
+++ b/aomaker/_aomaker.py
@@ -88,8 +88,9 @@ def async_api(cycle_func: Callable, jsonpath_expr: Union[Text, List], expr_index
                 logger.info(
                     f"==========后置异步接口断言开始<{func.__name__}>: 轮询函数<{cycle_func.__name__}>==========")
                 async_res = cycle_func(job_id, *out_args, **out_kwargs)
+                resp.setdefault("async_res", [])
                 if async_res:
-                    resp["async_res"] = async_res
+                    resp["async_res"].append(async_res)
                     return resp
                 logger.info(f"==========后置异步接口断言结束<{func.__name__}>==========")
             else:

--- a/aomaker/_aomaker.py
+++ b/aomaker/_aomaker.py
@@ -87,7 +87,10 @@ def async_api(cycle_func: Callable, jsonpath_expr: Union[Text, List], expr_index
 
                 logger.info(
                     f"==========后置异步接口断言开始<{func.__name__}>: 轮询函数<{cycle_func.__name__}>==========")
-                cycle_func(job_id, *out_args, **out_kwargs)
+                async_res = cycle_func(job_id, *out_args, **out_kwargs)
+                if async_res:
+                    resp["async_res"] = async_res
+                    return resp
                 logger.info(f"==========后置异步接口断言结束<{func.__name__}>==========")
             else:
                 logger.info(f"==========后置异步接口不满足执行条件，不执行<{func.__name__}>==========")

--- a/aomaker/_aomaker.py
+++ b/aomaker/_aomaker.py
@@ -15,7 +15,7 @@ from aomaker.cache import cache
 from aomaker.log import logger
 from aomaker.path import BASEDIR
 from aomaker.exceptions import FileNotFound, YamlKeyError, JsonPathExtractFailed
-from aomaker.hook_manager import _cli_hook, _session_hook
+from aomaker.hook_manager import cli_hook, session_hook
 from aomaker.models import ExecuteAsyncJobCondition
 
 
@@ -131,7 +131,7 @@ def command(name, **out_kwargs):
             option_handler.add_option(name, **out_kwargs)
             cmd.params.append(click.Option(option_handler.options.pop("name"), **option_handler.options))
             new_name = name.replace("-", "")
-            _cli_hook.register(func, new_name)
+            cli_hook.register(func, new_name)
 
         return wrapper
 
@@ -141,7 +141,7 @@ def command(name, **out_kwargs):
 def hook(func):
     @wraps(func)
     def wrapper():
-        _session_hook.register(func)
+        session_hook.register(func)
 
     return wrapper
 

--- a/aomaker/base/base_api.py
+++ b/aomaker/base/base_api.py
@@ -61,9 +61,6 @@ def response_callback(payload: dict):
         caller_of_class = caller_class_obj.__class__.__name__
         caller_of_method = api_caller.f_code.co_name
         caller_name = f"{caller_of_class}.{caller_of_method}"
-        # doc = caller_class_obj.__class__.__dict__[caller_of_method].__doc__  # 原代码
-
-        # 获取方法的文档字符串，无论它在当前类还是父类中定义
         method_ref = getattr(caller_class_obj, caller_of_method, None)
         doc = method_ref.__doc__ if method_ref and method_ref.__doc__ else ""
         doc = doc.split("\n")[0].strip() if doc else ""
@@ -102,16 +99,6 @@ def response_callback(payload: dict):
 
     return inner
 
-# 原代码
-# def _get_api_frame():
-#     current_frame = inspect.currentframe()
-#     outer_frames = inspect.getouterframes(current_frame)
-#     for frame_info in outer_frames[8:]:
-#         frame = frame_info.frame
-#         filename = frame_info.filename
-#         if API_DIR in filename:
-#             return frame
-
 
 def _get_api_frame():
     current_frame = inspect.currentframe()
@@ -120,7 +107,6 @@ def _get_api_frame():
         frame = frame_info.frame
         code = frame.f_code
         filename = frame_info.filename
-         # 修复子类重写send_http方法后,获取到的始终是调用类.send_http
         if API_DIR in filename and code.co_name != 'send_http':
             return frame
 

--- a/aomaker/hook_manager.py
+++ b/aomaker/hook_manager.py
@@ -1,6 +1,38 @@
 # --coding:utf-8--
+import inspect
+import sys
+from importlib import import_module
 
-class CommandHook:
+from aomaker.path import BASEDIR
+
+IS_LOADED = False
+
+
+class Hook:
+    HOOK_MODULE_NAME = "hooks"
+
+    def __call__(self, *args, **kwargs):
+        self.load_hooks()
+        return self
+
+    def load_hooks(self):
+        global IS_LOADED
+        if IS_LOADED is True:
+            return
+        print("🚀<AoMaker> 加载hooks...")
+        sys.path.append(BASEDIR)
+        try:
+            module_obj = import_module(self.HOOK_MODULE_NAME)
+        except ModuleNotFoundError:
+            return
+        for name, member in inspect.getmembers(module_obj):
+            if inspect.isfunction(member) and hasattr(member, '__wrapped__'):
+                # 被装饰的函数
+                member()
+        IS_LOADED = True
+
+
+class CommandHook(Hook):
     def __init__(self):
         self._callbacks = {}
         self.ctx = None
@@ -12,13 +44,6 @@ class CommandHook:
         """
         self._callbacks[name] = func
 
-    # def unregister(self, func):
-    #     """
-    #     取消注册回调函数。
-    #     """
-    #     if func in self._callbacks:
-    #         self._callbacks.remove(func)
-
     def run(self):
         """
         运行所有已注册的回调函数。
@@ -29,17 +54,41 @@ class CommandHook:
                 self._callbacks[param](value)
 
 
-class SessionHook:
+class SessionHook(Hook):
+
     def __init__(self):
-        self._callbacks = []
+        self.hooks = []
+        self.generators = []
+        self.generator_functions = []
 
     def register(self, func):
-        self._callbacks.append(func)
+        if inspect.isgeneratorfunction(func):
+            self.generator_functions.append(func)
+        else:
+            self.hooks.append(func)
 
-    def run(self):
-        for func in self._callbacks:
-            func()
+    def execute_pre_hooks(self):
+        if self.hooks:
+            print("🚀<AoMaker> 开始执行pre hooks...")
+            for hook in self.hooks:
+                hook()
+
+        if self.generator_functions:
+            print("🚀<AoMaker> 开始执行pre hooks...")
+            for func in self.generator_functions:
+                generator = func()
+                self.generators.append(generator)
+                next(generator)
+
+    def execute_post_hooks(self):
+        if self.generators:
+            print("🚀<AoMaker> 开始执行post hooks...")
+            for generator in self.generators:
+                try:
+                    next(generator)
+                except StopIteration:
+                    pass
 
 
-_cli_hook = CommandHook()
-_session_hook = SessionHook()
+cli_hook = CommandHook()
+session_hook = SessionHook()

--- a/aomaker/runner.py
+++ b/aomaker/runner.py
@@ -15,7 +15,8 @@ from aomaker._constants import Allure
 from aomaker.exceptions import LoginError
 from aomaker.path import REPORT_DIR, PYTEST_INI_DIR
 from aomaker.report import gen_reports
-from aomaker.hook_manager import _cli_hook, _session_hook
+
+from aomaker.hook_manager import cli_hook, session_hook
 
 allure_json_dir = os.path.join(REPORT_DIR, "json")
 RUN_MODE = {
@@ -27,11 +28,13 @@ RUN_MODE = {
 
 def fixture_session(func):
     """全局夹具装饰器"""
+
     def wrapper(*args, **kwargs):
         # Login登录类对象
         login = kwargs.get('login')
         _init(func, login)
         r = func(*args, **kwargs)
+        session_hook.execute_post_hooks()
         TearDownSession().clear_env()
         return r
 
@@ -44,9 +47,9 @@ def _init(func, login):
     config.set("run_mode", RUN_MODE[method_of_class_name])
     SetUpSession(login).set_session_vars()
     shutil.rmtree(allure_json_dir, ignore_errors=True)
-    if _cli_hook.custom_kwargs:
-        _cli_hook.run()
-    _session_hook.run()
+    if cli_hook.custom_kwargs:
+        cli_hook.run()
+    session_hook().execute_pre_hooks()
 
 
 class Runner:


### PR DESCRIPTION
-fix: 修复run.py无法启动hooks的问题(可以无痛debug了)
-refactor: hook_manager重构优化，现在@hook支持全局后置操作
-refactor: BaseApi不再强制校验response.status>=400，通过类属性IS_CHECK_RESPONSE_OK控制（默认校验）
-refactor: send_http不再强制将response转换为json,可通过类属性RESPONSE_TO_JSON控制是否转换（默认转换）